### PR TITLE
Lint .vue files using eslint-plugin-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "css-loader": "^1.0.0",
+    "eslint-plugin-html": "^4.0.5",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^3.2.0",
     "leaflet": "^1.3.1",
@@ -29,6 +30,6 @@
     "start": "webpack-dev-server --mode development --progress --open",
     "build:dev": "webpack --mode development",
     "build:prod": "webpack --mode production",
-    "test": "standard"
+    "test": "standard --plugin html \"**/*.{js,vue}\""
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'app',
+  name: 'app'
 }
 </script>

--- a/src/components/EventPane.vue
+++ b/src/components/EventPane.vue
@@ -8,19 +8,19 @@
 <script>
 export default {
   name: 'event',
-  data() {
+  data () {
     return {
-      event: null,
-    };
+      event: null
+    }
   },
-  created() {
-    let _this = this;
+  created () {
+    let _this = this
     this.$citygram.getEvent(this.$route.params.id).then(function (event) {
-      _this.event = event;
+      _this.event = event
     }).catch(function (error) {
       // TODO handle error
-      console.log(error);
-    });
-  },
+      console.log(error)
+    })
+  }
 }
 </script>

--- a/src/components/NoticesMap.vue
+++ b/src/components/NoticesMap.vue
@@ -11,21 +11,22 @@
 </template>
 
 <script>
-import 'leaflet/dist/leaflet.css';
+import 'leaflet/dist/leaflet.css'
 
 // fix issue with css-loader rewriting urls in leaflet CSS
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css';
-import 'leaflet-defaulticon-compatibility';
+import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
+import 'leaflet-defaulticon-compatibility'
 
-import { LMap, LTileLayer, LGeoJson, LMarker } from 'vue2-leaflet';
+import L from 'leaflet'
+import { LMap, LTileLayer, LGeoJson, LMarker } from 'vue2-leaflet'
 
 export default {
   name: 'notices-map',
   components: { LMap, LTileLayer, LMarker, LGeoJson },
-  data() {
-    const lat = this.$route.query.lat || 0;
-    const lng = this.$route.query.lng || 0;
-    const zoom = this.$route.query.zoom || 20;
+  data () {
+    const lat = this.$route.query.lat || 0
+    const lng = this.$route.query.lng || 0
+    const zoom = this.$route.query.zoom || 20
 
     return {
       zoom: zoom,
@@ -33,19 +34,19 @@ export default {
       url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
       marker: L.latLng(lat, lng),
-      events: [],
-    };
+      events: []
+    }
   },
-  created() {
-    let _this = this;
-    navigator.geolocation.getCurrentPosition(function(position) {
-      _this.center = L.latLng(position.coords.latitude, position.coords.longitude);
-      _this.marker = L.latLng(position.coords.latitude, position.coords.longitude);
-    });
+  created () {
+    let _this = this
+    navigator.geolocation.getCurrentPosition(function (position) {
+      _this.center = L.latLng(position.coords.latitude, position.coords.longitude)
+      _this.marker = L.latLng(position.coords.latitude, position.coords.longitude)
+    })
   },
   methods: {
-    updateEvents: function(bounds) {
-      let _this = this;
+    updateEvents: function (bounds) {
+      let _this = this
 
       let geometry = {
         type: 'Polygon',
@@ -56,22 +57,22 @@ export default {
           [bounds._southWest.lng, bounds._southWest.lat],
           [bounds._southWest.lng, bounds._northEast.lat]
         ]]
-      };
+      }
 
       this.$citygram.getEvents(geometry)
         .then(function (events) {
-          _this.events = events;
+          _this.events = events
         }).catch(function (error) {
           // TODO handle error
-          console.log(error);
-        });
+          console.log(error)
+        })
     },
-    onMoveEnd: function(e) {
-      this.updateEvents(e.target.getBounds());
+    onMoveEnd: function (e) {
+      this.updateEvents(e.target.getBounds())
     },
-    openEvent: function(e) {
-      this.$router.push({name: 'event', params: { id: e.layer.feature.id }});
-    },
-  },
+    openEvent: function (e) {
+      this.$router.push({name: 'event', params: { id: e.layer.feature.id }})
+    }
+  }
 }
 </script>

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -7,15 +7,13 @@
 </template>
 
 <script>
-import Vue from 'vue'
-
 export default {
   name: 'start-page',
-  data: function() {
+  data: function () {
     return {
       lat: process.env.VUE_APP_MAP_LAT,
-      lng: process.env.VUE_APP_MAP_LNG,
+      lng: process.env.VUE_APP_MAP_LNG
     }
-  },
+  }
 }
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,7 +1141,7 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
 
-domelementtype@1:
+domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
@@ -1155,6 +1155,12 @@ domhandler@2.1:
   dependencies:
     domelementtype "1"
 
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
+  dependencies:
+    domelementtype "1"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
@@ -1164,6 +1170,13 @@ domutils@1.1:
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -1221,7 +1234,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
@@ -1307,6 +1320,12 @@ eslint-module-utils@^2.1.1:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
+
+eslint-plugin-html@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-4.0.5.tgz#e8ec7e16485124460f3bff312016feb0a54d9659"
+  dependencies:
+    htmlparser2 "^3.8.2"
 
 eslint-plugin-import@~2.9.0:
   version "2.9.0"
@@ -1951,6 +1970,17 @@ html-webpack-plugin@^3.2.0:
     tapable "^1.0.0"
     toposort "^1.0.0"
     util.promisify "1.0.0"
+
+htmlparser2@^3.8.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 htmlparser2@~3.3.0:
   version "3.3.0"


### PR DESCRIPTION
Initially attempted to integrate eslint-plugin-vue, but couldn't get
this working with standardjs (it seems to be geared towards running
eslint directly with additional configuration).

May revisit switching to eslint in the future, but for now the html
plugin seems to do a reasonable job (parsing the code within <script>
tags).