### PR TITLE
Add instructions for pointing at staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# VUE_APP_CITYGRAM_URL="https://citygram-sf-staging.herokuapp.com" # point to staging
 VUE_APP_CITYGRAM_URL="http://$(docker-compose port citygram 9292)"
 VUE_APP_CITYGRAM_TAG='san-francisco' # controls which publishers to query for; should match tag in Citygram
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ diagram](https://github.com/codeforamerica/citygram/blob/master/images/citygram_
 
 # Development
 
+## Quick start
+
 * Install nodejs@10.6
   * Use of [nvm](https://github.com/creationix/nvm) recommended
 * Install [`yarn`](https://yarnpkg.com)
@@ -17,6 +19,13 @@ diagram](https://github.com/codeforamerica/citygram/blob/master/images/citygram_
 * Copy environment file examples
   * `cp .env.example .env`
     * Load this using autoenv, direnv, or other
+  * Switch `VUE_APP_CITYGRAM_URL` to point to staging
+
+## Using docker-compose
+
+To run against a local Citygram and Citygram Services, do the above (minus updating `VUE_APP_CITYGRAM_URL`) and then:
+
+* Copy environment file examples
   * `cp .citygram.env.example .citygram.env`
   * `cp .citygram-services.env.example .citygram-services.env`
     * Set `$SOCRATA_APP_TOKEN` in order to use endpoints that consume the Socrata API. See


### PR DESCRIPTION
As an alternative to running Citygram and Citygram Services locally.

Should make local testing easier if offline development is not needed.