### PR TITLE
Configure CircleCI to deploy to Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,69 @@
-version: 2
+version: 2.0
+
 jobs:
+  checkout:
+    docker:
+      - image: circleci/buildpack-deps:stable
+    steps:
+      - checkout
+      - save_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/project # Would like to use .Environment.CIRCLE_WORKING_DIRECTORY, but this doesn't appear to interpolate here
+
   build:
     docker:
       - image: circleci/node:10.6
     steps:
-      - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:
-          name: install
+          name: Installing Yarn dependencies
           command: yarn install
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
+
+  test:
+    docker:
+      - image: circleci/node:10.6
+    steps:
+      - restore_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache: # restore cache from build
+          key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:
-          name: test
+          name: Running npm tests
           command: npm test
+
+  deploy:
+    docker:
+      - image: circleci/buildpack-deps:stable
+    steps:
+      - restore_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Deploying to Heroku
+          command: |
+            git push --force https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git $CIRCLE_SHA1:master
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - checkout
+      - build:
+          requires:
+            - checkout
+      - test:
+          requires:
+            - build
+      - deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Also:

* Refactor to use workflows to keep it cleaner
* Name steps in a pattern closer to CircleCI's default steps

Currently uses my API token, but I've created a task to move it when the Heroku app is moved.