### PR TITLE
Start of the notification subscription page

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -61,7 +61,8 @@
 
 <script>
 import moment from 'moment'
-import { L, LGeoJson } from 'vue2-leaflet'
+import L from 'leaflet'
+import { LGeoJson } from 'vue2-leaflet'
 
 // TODO
 //   * Remove the word permit and put into data to generalize

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -45,10 +45,9 @@
     <div class="section">
       <h2>Permit location</h2>
       <div class='map-container'>
-        <l-map :options=mapOptions :bounds=mapBounds>
-          <l-tile-layer :url="url" :attribution="attribution"></l-tile-layer>
+        <static-map :bounds=mapBounds>
           <l-geo-json :geojson="event"></l-geo-json>
-        </l-map>
+        </static-map>
       </div>
       <p v-if="event.properties.location">
         {{ event.properties.location }}
@@ -61,40 +60,25 @@
 </template>
 
 <script>
+import moment from 'moment'
+import { L, LGeoJson } from 'vue2-leaflet'
+
 // TODO
 //   * Remove the word permit and put into data to generalize
-import 'leaflet/dist/leaflet.css'
-
-// fix issue with css-loader rewriting urls in leaflet CSS
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
-import 'leaflet-defaulticon-compatibility'
-
-import L from 'leaflet'
-import { LMap, LTileLayer, LGeoJson } from 'vue2-leaflet'
-
-import moment from 'moment'
 import formatPhoneNumber from '../filters/FormatPhoneNumber.js'
+
+import StaticMap from './StaticMap.vue'
 
 export default {
   name: 'event',
-  components: { Map, LMap, LTileLayer, LGeoJson },
+  components: { StaticMap, LGeoJson },
   data () {
     return {
       event: {
         type: 'Feature',
         geometry: null,
         properties: {}
-      },
-      mapOptions: {
-        // do not let the user interact with the map
-        zoomControl: false,
-        boxZoom: false,
-        doubleClickZoom: false,
-        dragging: false,
-        scrollWheelZoom: false
-      },
-      url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
-      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }
     }
   },
   filters: {

--- a/src/components/NotificationsSignup.vue
+++ b/src/components/NotificationsSignup.vue
@@ -92,7 +92,7 @@ export default {
       // calculate the bounds based on the center point (lat, lng) and distance
       // this is an approximation (only works for small distances relative to R and not close to the poles)
       // based on https://stackoverflow.com/questions/7477003/calculating-new-longitude-latitude-from-old-n-meters
-      const R = 6378 // distance of Earth in km
+      const R = 6378 // radius of Earth in km
       const distance = this.distance / 2 / 1000 // extend 1/2 distance in the 4 cardinal directions, convert to km
 
       const [latitude, longitude] = [this.$store.state.userLat, this.$store.state.userLng]

--- a/src/components/NotificationsSignup.vue
+++ b/src/components/NotificationsSignup.vue
@@ -1,0 +1,145 @@
+<template>
+  <div>
+    <!-- pattern-lab/molecules-hero-banner -->
+    <header class="sfgov-banner">
+      <div class="sfgov-banner__container sfgov-container">
+        <h1>Get future notifications</h1>
+      </div>
+    </header>
+
+    <form v-on:submit.prevent="onSubmit">
+      <div>
+        <label for="address">From this address: </label>
+        <input v-model="address" required>
+      </div>
+
+      <fieldset>
+        <legend>Within a distance of: </legend>
+
+        <!-- distances in meters -->
+
+        <input type="radio" id="500_feet" v-model.number="distance" value="152" />
+        <label for="500_feet">500 feet</label>
+
+        <input type="radio" id="1_4_mile" v-model.number="distance" value="402" />
+        <label for="1_4_mile">1/4 mile</label>
+
+        <input type="radio" id="1_2_mile" v-model.number="distance" value="804" />
+        <label for="1_2_mile">1/2 mile</label>
+
+        <input type="radio" id="1_mile" v-model.number="distance" value="1609" />
+        <label for="1_mile">1 mile</label>
+
+        <input type="radio" id="5_mile" v-model.number="distance" value="8046" />
+        <label for="5_mile">5 miles</label>
+      </fieldset>
+
+      <div class='map-container'>
+        <l-map :options=map.options :bounds=map.bounds>
+          <l-tile-layer :url=map.url :attribution=map.attribution></l-tile-layer>
+
+          <!-- center -->
+          <l-marker :lat-lng="map.marker"></l-marker>
+
+          <!-- only used to determine the rectangle bounds -->
+          <l-circle ref="circle" :stroke=false :fillOpacity=0 :lat-lng=map.marker :radius=distance></l-circle>
+
+          <l-rectangle :bounds=subscriptionBounds></l-rectangle>
+        </l-map>
+      </div>
+
+      <fieldset>
+        <legend>How would you like to receive notifications?</legend>
+
+        <input type="radio" id="individual_text" v-model="contact_medium" value="individual_email" />
+        <label for="individual_text">Individual emails</label>
+
+        <input type="radio" id="weekly_email" v-model="contact_medium" value="weekly_email" />
+        <label for="weekly_email">Weekly email summaries</label>
+      </fieldset>
+
+      <div>
+        <label for="contact_address">Email address: </label>
+        <input type="text" v-model="contact_address" id="contact_address" required>
+      </div>
+
+      <div>
+        <input class="sfgov-button" type="submit" value="Subscribe">
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import 'leaflet/dist/leaflet.css'
+
+// fix issue with css-loader rewriting urls in leaflet CSS
+import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
+import 'leaflet-defaulticon-compatibility'
+
+import L from 'leaflet'
+import { LMap, LTileLayer, LRectangle, LCircle, LMarker } from 'vue2-leaflet'
+
+// TODO
+// wire up address field
+export default {
+  name: 'NotificationsSignup',
+  components: { LMap, LTileLayer, LCircle, LRectangle, LMarker },
+  data () {
+    return {
+      // form
+      address: '500 Collingwood Street',
+      distance: 152,
+      contact_medium: 'individual_email',
+      contact_address: '',
+
+      subscriptionBounds: [ [0, 0], [0, 0] ],
+
+      map: {
+        bounds: null,
+        marker: L.latLng(this.$store.state.userLat, this.$store.state.userLng),
+        url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
+        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+        options: {
+          // do not let the user interact with the map
+          zoomControl: false,
+          boxZoom: false,
+          doubleClickZoom: false,
+          dragging: false,
+          scrollWheelZoom: false
+        }
+      }
+    }
+  },
+  watch: {
+    // update bounds when distance and circle is redrawn
+    // attempted to do by binding the map bounds to the circle bounds, but got into a loop with the circle bounds
+    // updating every time the map bounds changed
+    distance: function (newDistance, oldDistance) {
+      this.$nextTick(() => {
+        this.updateBounds(this.$refs.circle.mapObject.getBounds())
+      })
+    }
+  },
+  methods: {
+    updateBounds: function (bounds) {
+      this.map.bounds = bounds
+      this.subscriptionBounds = [bounds.getNorthWest(), bounds.getSouthEast()]
+    },
+    onSubmit: function () {
+      console.log(this)
+    }
+  },
+  mounted: function () {
+    this.$nextTick(() => {
+      this.updateBounds(this.$refs.circle.mapObject.getBounds())
+    })
+  }
+}
+</script>
+
+<style>
+.map-container {
+  height: 200px;
+}
+</style>

--- a/src/components/NotificationsSignup.vue
+++ b/src/components/NotificationsSignup.vue
@@ -46,16 +46,16 @@
       <fieldset>
         <legend>How would you like to receive notifications?</legend>
 
-        <input type="radio" id="individual_text" v-model="contact_medium" value="individual_email" />
-        <label for="individual_text">Individual emails</label>
+        <input type="radio" id="individual_text" v-model="frequency" value="individual" />
+        <label for="individual">Individual emails</label>
 
-        <input type="radio" id="weekly_email" v-model="contact_medium" value="weekly_email" />
-        <label for="weekly_email">Weekly email summaries</label>
+        <input type="radio" id="weekly_email" v-model="frequency" value="weekly" />
+        <label for="weekly">Weekly email summaries</label>
       </fieldset>
 
       <div>
-        <label for="contact_address">Email address: </label>
-        <input type="text" v-model="contact_address" id="contact_address" required>
+        <label for="email">Email address: </label>
+        <input type="text" v-model="email" id="email" required>
       </div>
 
       <div>
@@ -81,8 +81,8 @@ export default {
       // form
       address: '500 Collingwood Street',
       distance: 152,
-      contact_medium: 'individual_email',
-      contact_address: '',
+      frequency: 'individual',
+      email: '',
 
       marker: L.latLng(this.$store.state.userLat, this.$store.state.userLng)
     }
@@ -108,7 +108,7 @@ export default {
   },
   methods: {
     onSubmit: function () {
-      console.log(this)
+      console.log(this.$data)
     }
   }
 }

--- a/src/components/NotificationsSignup.vue
+++ b/src/components/NotificationsSignup.vue
@@ -46,10 +46,10 @@
       <fieldset>
         <legend>How would you like to receive notifications?</legend>
 
-        <input type="radio" id="individual_text" v-model="frequency" value="individual" />
+        <input type="radio" id="individual" v-model="frequency" value="individual" />
         <label for="individual">Individual emails</label>
 
-        <input type="radio" id="weekly_email" v-model="frequency" value="weekly" />
+        <input type="radio" id="weekly" v-model="frequency" value="weekly" />
         <label for="weekly">Weekly email summaries</label>
       </fieldset>
 

--- a/src/components/NotificationsSignup.vue
+++ b/src/components/NotificationsSignup.vue
@@ -35,17 +35,15 @@
       </fieldset>
 
       <div class='map-container'>
-        <l-map :options=map.options :bounds=map.bounds>
-          <l-tile-layer :url=map.url :attribution=map.attribution></l-tile-layer>
-
+        <static-map :bounds=mapBounds>
           <!-- center -->
-          <l-marker :lat-lng="map.marker"></l-marker>
+          <l-marker :lat-lng="marker"></l-marker>
 
           <!-- only used to determine the rectangle bounds -->
-          <l-circle ref="circle" :stroke=false :fillOpacity=0 :lat-lng=map.marker :radius=distance></l-circle>
+          <l-circle ref="circle" :stroke=false :fillOpacity=0 :lat-lng=marker :radius=distance></l-circle>
 
           <l-rectangle :bounds=subscriptionBounds></l-rectangle>
-        </l-map>
+        </static-map>
       </div>
 
       <fieldset>
@@ -71,20 +69,16 @@
 </template>
 
 <script>
-import 'leaflet/dist/leaflet.css'
-
-// fix issue with css-loader rewriting urls in leaflet CSS
-import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
-import 'leaflet-defaulticon-compatibility'
-
 import L from 'leaflet'
-import { LMap, LTileLayer, LRectangle, LCircle, LMarker } from 'vue2-leaflet'
+import { LRectangle, LCircle, LMarker } from 'vue2-leaflet'
+
+import StaticMap from './StaticMap.vue'
 
 // TODO
 // wire up address field
 export default {
   name: 'NotificationsSignup',
-  components: { LMap, LTileLayer, LCircle, LRectangle, LMarker },
+  components: { StaticMap, LCircle, LRectangle, LMarker },
   data () {
     return {
       // form
@@ -95,20 +89,8 @@ export default {
 
       subscriptionBounds: [ [0, 0], [0, 0] ],
 
-      map: {
-        bounds: null,
-        marker: L.latLng(this.$store.state.userLat, this.$store.state.userLng),
-        url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
-        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-        options: {
-          // do not let the user interact with the map
-          zoomControl: false,
-          boxZoom: false,
-          doubleClickZoom: false,
-          dragging: false,
-          scrollWheelZoom: false
-        }
-      }
+      mapBounds: null,
+      marker: L.latLng(this.$store.state.userLat, this.$store.state.userLng)
     }
   },
   watch: {
@@ -123,7 +105,7 @@ export default {
   },
   methods: {
     updateBounds: function (bounds) {
-      this.map.bounds = bounds
+      this.mapBounds = bounds
       this.subscriptionBounds = [bounds.getNorthWest(), bounds.getSouthEast()]
     },
     onSubmit: function () {

--- a/src/components/NotificationsSignup.vue
+++ b/src/components/NotificationsSignup.vue
@@ -73,6 +73,8 @@ import StaticMap from './StaticMap.vue'
 
 // TODO
 // wire up address field
+// add form validation
+// actually create subscriptions
 export default {
   name: 'NotificationsSignup',
   components: { StaticMap, LCircle, LRectangle, LMarker },

--- a/src/components/StaticMap.vue
+++ b/src/components/StaticMap.vue
@@ -1,0 +1,45 @@
+<template>
+  <l-map :options=options :bounds=bounds>
+    <l-tile-layer :url=url :attribution=attribution></l-tile-layer>
+
+    <slot></slot>
+  </l-map>
+</template>
+
+<script>
+import 'leaflet/dist/leaflet.css'
+
+// fix issue with css-loader rewriting urls in leaflet CSS
+import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
+import 'leaflet-defaulticon-compatibility'
+
+import { LMap, LTileLayer } from 'vue2-leaflet'
+
+export default {
+  name: 'StaticMap',
+  components: { LMap, LTileLayer },
+  props: {
+    bounds: {
+      custom: true,
+      default: undefined
+    }
+  },
+  data () {
+    return {
+      url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
+      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+      options: {
+        // do not let the user interact with the map
+        zoomControl: false,
+        boxZoom: false,
+        doubleClickZoom: false,
+        dragging: false,
+        scrollWheelZoom: false
+      }
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,8 @@ import Events from '../components/Events.vue'
 import EventList from '../components/EventList.vue'
 import EventMap from '../components/EventMap.vue'
 
+import NotificationsSignup from '../components/NotificationsSignup.vue'
+
 Vue.use(Router)
 
 export default new Router({
@@ -23,6 +25,7 @@ export default new Router({
         { name: 'events_list', path: 'list', component: EventList }
       ]
     },
-    { name: 'event', path: '/events/:id', component: Event }
+    { name: 'event', path: '/events/:id', component: Event },
+    { name: 'notifications_signup', path: '/notifications/get', component: NotificationsSignup }
   ]
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,13 +3,13 @@
 function Store () {
   return {
     state: { // do not mutate directly
-      userLat: process.env.VUE_APP_MAP_LAT,
-      userLng: process.env.VUE_APP_MAP_LNG
+      userLat: Number(process.env.VUE_APP_MAP_LAT),
+      userLng: Number(process.env.VUE_APP_MAP_LNG)
     },
 
     setUserLocation: function (lat, lng) {
-      this.state.userLat = lat
-      this.state.userLng = lng
+      this.state.userLat = Number(lat)
+      this.state.userLng = Number(lng)
     }
   }
 }


### PR DESCRIPTION
Again, a work in progress, but wanted to start to get feedback.

See https://sfgov.invisionapp.com/share/YTNEC4FPHQN#/screens/313091167_Get_future_notifications for Invision prototype. This differs a bit in that it:

* Drops the type since it confused users
* Adds a preview of the subscription location
* Swaps the "Individual texts" option for "Individual emails" since user testing seemed to indicate that users only wanted emails for this content and the option to get one email per event was mentioned.

This PR does a few things:

* Creates basic notification subscription page
* Refactors out the static map into a new component since it is shared between this component and the Event component
* Ensures that the userLat and userLng store values are numbers to avoid issues with doing arithmetic with `+` (was concatenating)

For now, the form just console.log's when POSTed. I'll need to wire it up to the Citygram API, but I found I'll need to do some work over there to get individual email alerts setup.

Also still need to wire up the address search.