### PR TITLE
Some map styling and enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "html-webpack-plugin": "^3.2.0",
     "leaflet": "^1.3.1",
     "leaflet-defaulticon-compatibility": "^0.1.1",
+    "leaflet.locatecontrol": "^0.62.0",
     "libphonenumber-js": "^1.4.2",
     "moment": "^2.22.2",
     "sfgov-pattern-lab": "https://github.com/SFDigitalServices/sfgov-pattern-lab.git#do-not-run-pattern-lab-on-install",

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -2,7 +2,7 @@
   <div>
     <div class='map-container'>
       <static-map :bounds=mapBounds>
-        <l-geo-json :geojson="event"></l-geo-json>
+        <event-feature :event=event></event-feature>
       </static-map>
     </div>
 
@@ -72,17 +72,17 @@
 <script>
 import moment from 'moment'
 import L from 'leaflet'
-import { LGeoJson } from 'vue2-leaflet'
 
 // TODO
 //   * Remove the word permit and put into data to generalize
 import formatPhoneNumber from '../filters/FormatPhoneNumber.js'
 
 import StaticMap from './StaticMap.vue'
+import EventFeature from './EventFeature.vue'
 
 export default {
   name: 'event',
-  components: { StaticMap, LGeoJson },
+  components: { StaticMap, EventFeature },
   data () {
     return {
       event: {

--- a/src/components/EventFeature.vue
+++ b/src/components/EventFeature.vue
@@ -10,6 +10,13 @@
 import L from 'leaflet'
 import { findRealParent, LGeoJson } from 'vue2-leaflet'
 
+/**
+ * Represents an event to be rendered on a map. Delegates to the LGeoJson component, but changes points to be rendered
+ * as small circles. I anticipate that we can include more feature styling in this file if we start to pull in
+ * non-point features.
+ *
+ * Expects to be included within an `LMap` Vue2Leaflet component.
+ */
 export default {
   name: 'EventFeature',
   components: { LGeoJson },

--- a/src/components/EventFeature.vue
+++ b/src/components/EventFeature.vue
@@ -1,0 +1,52 @@
+<template>
+  <l-geo-json
+    :geojson="event"
+    :options=eventOptions
+    @click="onClick"
+  ></l-geo-json>
+</template>
+
+<script>
+import L from 'leaflet'
+import { findRealParent, LGeoJson } from 'vue2-leaflet'
+
+export default {
+  name: 'EventFeature',
+  components: { LGeoJson },
+  props: {
+    event: {
+      type: Object,
+      default: {}
+    }
+  },
+  methods: {
+    onClick: function (e) {
+      this.$emit('click', this.event)
+    }
+  },
+  mounted: function () {
+    // l-geo-json expects this to be set
+    this.mapObject = findRealParent(this.$parent).mapObject
+  },
+  data () {
+    return {
+      eventOptions: {
+        // convert points to small circles
+        pointToLayer: function (feature, latlng) {
+          return L.circleMarker(latlng, {
+            radius: 8,
+            fillColor: '#0071bc', // same color as primary buttons
+            color: '#000',
+            weight: 1,
+            opacity: 1,
+            fillOpacity: 0.8
+          })
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/EventMap.vue
+++ b/src/components/EventMap.vue
@@ -7,12 +7,7 @@
           >
     <l-tile-layer :url="url" :attribution="attribution"></l-tile-layer>
     <l-control-locate :locate-on-mount=locateOnMount @locationfound=locationFound></l-control-locate>
-    <l-geo-json v-for="event in events"
-      :key="event.id"
-      :geojson="event"
-      :options=eventOptions
-      @click="openEvent"
-    ></l-geo-json>
+    <event-feature v-for="event in events" :key="event.id" :event=event @click=eventSelected></event-feature>
   </l-map>
 </template>
 
@@ -26,12 +21,14 @@ import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility
 import 'leaflet-defaulticon-compatibility'
 
 import L from 'leaflet'
-import { LMap, LTileLayer, LGeoJson, LMarker } from 'vue2-leaflet'
+import { LMap, LTileLayer } from 'vue2-leaflet'
+
 import LControlLocate from './LControlLocate.vue'
+import EventFeature from './EventFeature.vue'
 
 export default {
   name: 'EventMap',
-  components: { LMap, LTileLayer, LMarker, LGeoJson, LControlLocate },
+  components: { LMap, LTileLayer, LControlLocate, EventFeature },
   props: {
     center: {
       type: Array, // [lat, lng]
@@ -53,20 +50,7 @@ export default {
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
 
       state: this.$store.state,
-      locateOnMount: locate,
-      eventOptions: {
-        // convert points to small circles
-        pointToLayer: function (feature, latlng) {
-          return L.circleMarker(latlng, {
-            radius: 8,
-            fillColor: '#0071bc', // same color as primary buttons
-            color: '#000',
-            weight: 1,
-            opacity: 1,
-            fillOpacity: 0.8
-          })
-        }
-      }
+      locateOnMount: locate
     }
   },
   computed: {
@@ -96,8 +80,8 @@ export default {
       this.$store.setUserLocation(loc.latitude, loc.longitude)
     },
 
-    openEvent: function (e) {
-      this.$emit('event-selected', e.layer.feature.id)
+    eventSelected: function (event) {
+      this.$emit('event-selected', event.id)
     }
   }
 }

--- a/src/components/EventMap.vue
+++ b/src/components/EventMap.vue
@@ -6,7 +6,7 @@
           @moveend="moveEnd"
           >
     <l-tile-layer :url="url" :attribution="attribution"></l-tile-layer>
-    <l-marker :lat-lng="userLocation"></l-marker>
+    <l-control-locate :locate-on-mount=locateOnMount @locationfound=locationFound></l-control-locate>
     <l-geo-json v-for="event in events"
       :key="event.id"
       :geojson="event"
@@ -27,10 +27,11 @@ import 'leaflet-defaulticon-compatibility'
 
 import L from 'leaflet'
 import { LMap, LTileLayer, LGeoJson, LMarker } from 'vue2-leaflet'
+import LControlLocate from './LControlLocate.vue'
 
 export default {
   name: 'EventMap',
-  components: { LMap, LTileLayer, LMarker, LGeoJson },
+  components: { LMap, LTileLayer, LMarker, LGeoJson, LControlLocate },
   props: {
     center: {
       type: Array, // [lat, lng]
@@ -46,11 +47,13 @@ export default {
     }
   },
   data () {
+    const locate = ('locate' in this.$route.query)
     return {
       url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
 
       state: this.$store.state,
+      locateOnMount: locate,
       eventOptions: {
         // convert points to small circles
         pointToLayer: function (feature, latlng) {
@@ -88,6 +91,11 @@ export default {
         this.$emit('update:zoom', e.target.getZoom())
       }
     },
+
+    locationFound: function (loc) {
+      this.$store.setUserLocation(loc.latitude, loc.longitude)
+    },
+
     openEvent: function (e) {
       this.$emit('event-selected', e.layer.feature.id)
     }

--- a/src/components/EventMap.vue
+++ b/src/components/EventMap.vue
@@ -10,6 +10,7 @@
     <l-geo-json v-for="event in events"
       :key="event.id"
       :geojson="event"
+      :options=eventOptions
       @click="openEvent"
     ></l-geo-json>
   </l-map>
@@ -49,7 +50,20 @@ export default {
       url: 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
 
-      state: this.$store.state
+      state: this.$store.state,
+      eventOptions: {
+        // convert points to small circles
+        pointToLayer: function (feature, latlng) {
+          return L.circleMarker(latlng, {
+            radius: 8,
+            fillColor: '#0071bc', // same color as primary buttons
+            color: '#000',
+            weight: 1,
+            opacity: 1,
+            fillOpacity: 0.8
+          })
+        }
+      }
     }
   },
   computed: {

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -131,8 +131,6 @@ export default {
       const northEastBound = destination(centerPoint, diagonalDistance, angle, {units: 'kilometers'})
       const southWestBound = destination(centerPoint, diagonalDistance, -90 - angle, {units: 'kilometers'})
 
-      console.log('query bounds', southWestBound.geometry.coordinates, northEastBound.geometry.coordinates)
-
       const bboxFeature = bboxPolygon([
         southWestBound.geometry.coordinates[0],
         southWestBound.geometry.coordinates[1],

--- a/src/components/LControlLocate.vue
+++ b/src/components/LControlLocate.vue
@@ -1,0 +1,45 @@
+<script>
+/*
+ * Wrap leaflet.locatecontrol library in a Vue component
+ * https://github.com/domoritz/leaflet-locatecontrol
+ *
+ * Will add configuration options as-needed
+ */
+
+import L from 'leaflet'
+import 'leaflet.locatecontrol'
+
+const props = {
+  // locate user when control is mounted
+  locateOnMount: {
+    type: Boolean,
+    default: false
+  }
+}
+
+export default {
+  name: 'LControlLocate',
+  props: props,
+  mounted () {
+    this.mapObject = L.control.locate({
+      locateOptions: {
+        maxZoom: 16 // TODO will delete this when merging in changes with configurable zoom
+      }
+    })
+    this.mapObject.addTo(this.$parent.mapObject)
+    this.$parent.mapObject.on('locationfound', (e) => {
+      this.$emit('locationfound', e)
+    })
+
+    if (this.locateOnMount) {
+      this.mapObject.start()
+    }
+  },
+  beforeDestroy () {
+    this.mapObject.stop()
+  },
+  render () {
+    return null
+  }
+}
+</script>

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -12,7 +12,7 @@
 
     <div class="nav-buttons">
       <div class="main">
-        <button @click="findLocation" class="sfgov-button">Get Started</button>
+        <router-link tag="button" :to="{ name: 'events_map', query: { locate: true, lat: lat, lng: lng } }">Get started</router-link>
       </div>
 
       <div>
@@ -31,15 +31,6 @@ export default {
       lat: process.env.VUE_APP_MAP_LAT,
       lng: process.env.VUE_APP_MAP_LNG,
       zoom: process.env.VUE_APP_MAP_ZOOM
-    }
-  },
-  methods: {
-    findLocation: function (e) {
-      let _this = this
-      navigator.geolocation.getCurrentPosition(function (position) {
-        _this.$store.setUserLocation(position.coords.latitude, position.coords.longitude)
-        _this.$router.push({ name: 'events_map', query: { lat: position.coords.latitude, lng: position.coords.longitude, zoom: _this.zoom } })
-      })
     }
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,8 +3,8 @@
 function Store () {
   return {
     state: { // do not mutate directly
-      userLat: Number(process.env.VUE_APP_MAP_LAT),
-      userLng: Number(process.env.VUE_APP_MAP_LNG)
+      userLat: null,
+      userLng: null
     },
 
     setUserLocation: function (lat, lng) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,6 +5206,10 @@ leaflet-defaulticon-compatibility@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/leaflet-defaulticon-compatibility/-/leaflet-defaulticon-compatibility-0.1.1.tgz#ab72257b3da66fb48dab69a10c3824012a15a20a"
 
+leaflet.locatecontrol@^0.62.0:
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.62.0.tgz#cf0c65170a87f2ed4b1a59e3307b773cd268d27d"
+
 leaflet@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.1.tgz#86f336d2fb0e2d0ff446677049a5dc34cf0ea60e"


### PR DESCRIPTION
Style events as small circles rather than the default LeafletJS markers.

Add locate.locatecontrol to the map to allow the user to locate
themselves. Useful if the user has panned and wants to return to their
location.

This changes the geolocation behavior on the start page to, instead of
doing the location and loading the map, simply load the map and ask the
map to locate the user (via the added locatecontrol). Though we wanted
to preserve the behavior of location before map load, I wasn't able to
get this to play nicely with rendering the user's location via the newly
added locate control which doesn't have an interface for setting the
current location (it depends on receiving a Leaflet.LocateEvent).
I Opened domoritz/leaflet-locatecontrol#209 to
get the maintainer's feedback on adding an interface to set the location.