### PR TITLE
Fill in event descriptions and type

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -32,7 +32,10 @@
         <p class="description">
           {{ event.properties.type.subtype.description }}
         </p>
-        <p><a href="#">{{ event.properties.type.name }}# {{ event.properties.id }}</a></p>
+        <!-- TODO link to an online representation of the event if one exists -->
+        <p>
+          {{ event.properties.type.name }}# {{ event.properties.id }}
+        </p>
       </div>
     </header>
 

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -9,7 +9,7 @@
     <!-- pattern-lab/molecules-hero-banner -->
     <header class="sfgov-banner">
       <div class="sfgov-banner__container sfgov-container">
-        <h1>{{ event.properties.type }} Permit</h1>
+        <h1>{{ event.properties.type.subtype.name }} {{ event.properties.type.name }}</h1>
 
         <a :href="mailtoHref">
           <i class="fas fa-share">Share</i>
@@ -30,9 +30,9 @@
         </p>
 
         <p class="description">
-          Description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sed lobortis erat, a hendrerit mauris. Proin nec turpis nunc. Fusce risus orci, ornare vel dictum eget, volutpat non purus. Donec vitae varius.
+          {{ event.properties.type.subtype.description }}
         </p>
-        <p><a href="#">Permit # {{ event.properties.id }}</a></p>
+        <p><a href="#">{{ event.properties.type.name }}# {{ event.properties.id }}</a></p>
       </div>
     </header>
 
@@ -104,7 +104,7 @@ export default {
   },
   computed: {
     mailtoHref: function () {
-      return 'mailto:?to=&subject=Permit #' + this.event.properties.id + '&body=' + window.location
+      return 'mailto:?to=&subject=' + this.event.properties.type.name + ' #' + this.event.properties.id + '&body=' + window.location
     },
     mapBounds: function () {
       if (!this.event || !this.event.geometry) {

--- a/src/components/EventListItem.vue
+++ b/src/components/EventListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div class='section'>
     <h2 @click="$emit('selected', event.id)">
-      {{ event.properties.type }}
+      {{ event.properties.type.subtype.name }} {{ event.properties.type.name }}
     </h2>
     <p>
       {{ event.properties.location }}


### PR DESCRIPTION
This:

* Pulls in the subtype description to populate on the event page
* Replaces usages of "Permit" with the type name to allow dynamic
  specification of the type of event

This required updating the `citygram-services` to return this new data (https://github.com/SFDigitalServices/citygram-services/commit/6bc232f3621a9766d4f04ec635bcd101c6267f04).