### PR TITLE
A few small fixes

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -95,7 +95,12 @@ export default {
       event: {
         type: 'Feature',
         geometry: null,
-        properties: {}
+        properties: {
+          type: {
+            subtype: {
+            }
+          }
+        }
       }
     }
   },

--- a/src/components/EventMap.vue
+++ b/src/components/EventMap.vue
@@ -80,7 +80,7 @@ export default {
       this.$store.setUserLocation(loc.latitude, loc.longitude)
       this.$router.replace({
         query: Object.assign({}, this.$route.query, {
-          locate: undefined,
+          locate: undefined
         })
       })
     },

--- a/src/components/EventMap.vue
+++ b/src/components/EventMap.vue
@@ -78,6 +78,11 @@ export default {
 
     locationFound: function (loc) {
       this.$store.setUserLocation(loc.latitude, loc.longitude)
+      this.$router.replace({
+        query: Object.assign({}, this.$route.query, {
+          locate: undefined,
+        })
+      })
     },
 
     eventSelected: function (event) {

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -126,12 +126,12 @@ export default {
 
       const diagonalPixels = Math.hypot(this.$refs.view.$el.clientHeight, this.$refs.view.$el.clientWidth)
 
-      const angle = Math.asin(this.$refs.view.$el.clientHeight / diagonalPixels) * (180 / Math.PI)
+      const angle = Math.asin(this.$refs.view.$el.clientWidth / diagonalPixels) * (180 / Math.PI)
 
       const centerPoint = [this.center[1], this.center[0]] // turf wants [lng, lat]
       const diagonalDistance = diagonalPixels / 2 * kilometersPerPixel(this.center[0], this.zoom)
       const northEastBound = destination(centerPoint, diagonalDistance, angle, {units: 'kilometers'})
-      const southWestBound = destination(centerPoint, diagonalDistance, -90 - angle, {units: 'kilometers'})
+      const southWestBound = destination(centerPoint, diagonalDistance, -180 + angle, {units: 'kilometers'})
 
       const bboxFeature = bboxPolygon([
         southWestBound.geometry.coordinates[0],

--- a/src/components/StartPage.vue
+++ b/src/components/StartPage.vue
@@ -13,7 +13,7 @@
 
       <div class="nav-buttons">
         <div class="main">
-          <router-link tag="button" :to="{ name: 'events_map', query: { locate: true, lat: lat, lng: lng } }">Get started</router-link>
+          <router-link tag="button" :to="{ name: 'events_map', query: { locate: true, lat: lat, lng: lng, zoom: zoom } }">Get started</router-link>
         </div>
 
         <div>


### PR DESCRIPTION
Including:

* Initialize new default event structure; avoids trying to access non-existant properties before the event is loaded
* Start map zoomed in on San Francisco before locating, rather than showing the whole world
* Unset locate query parameter when user is located; avoiding the situation where a user clicks an event, comes back to the map, and is then relocated.